### PR TITLE
Synchronise install and upgrade scripts

### DIFF
--- a/src/installer/install.sh
+++ b/src/installer/install.sh
@@ -2,5 +2,6 @@
 
 "$(dirname "${0}")/apt.sh"
 "$(dirname "${0}")/binary.sh"
-"$(dirname "${0}")/source.sh"
 "$(dirname "${0}")/uv_tool.sh"
+"$(dirname "${0}")/source.sh"
+"$(dirname "${0}")/image.sh"

--- a/src/installer/upgrade.sh
+++ b/src/installer/upgrade.sh
@@ -2,7 +2,9 @@
 
 sudo apt-get update
 sudo apt-get -y dist-upgrade
+sudo apt-get -y autoremove
 
+"$(dirname "${0}")/binary.sh"
 "$(dirname "${0}")/uv_tool.sh"
 "$(dirname "${0}")/source.sh"
 "$(dirname "${0}")/image.sh"


### PR DESCRIPTION
Synchronise their contents. In particular, uv was not upgraded because of missing binary.sh in the upgrade script.