### PR TITLE
Fix bootstrapping awscli

### DIFF
--- a/src/installer/uv_tool.sh
+++ b/src/installer/uv_tool.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -eux
 
 packages=(
-    'awscli'
     'hatch'
     'pdm'
     'poetry'
@@ -17,12 +16,16 @@ if ! command -v "${_install_dir}/uv" >/dev/null 2>&1; then
     eixt 1
 fi
 
-# Install
+# Install (package name == command name)
 for package in "${packages[@]}"; do
     if ! command -v "${_user_local_bin}/${package}" >/dev/null 2>&1; then
         "${_install_dir}/uv" tool install "${package}"
     fi
 done
+# Install (package name != command name)
+if ! command -v "${_user_local_bin}/aws" >/dev/null 2>&1; then
+    "${_install_dir}/uv" tool install awscli
+fi
 # Install (self-hosted)
 if ! command -v "${_user_local_bin}/gpkg" >/dev/null 2>&1; then
     "${_install_dir}/uv" tool install --from git+https://github.com/MtkN1/gpkg.git gpkg


### PR DESCRIPTION
`awscli` is the package name and `aws` is the command name. `uv_tools.sh` ignored the condition and tried to install every time, which generated a warning:

```sh-session
`awscli` is already installed
```