### PR TITLE
Ignore "pymanager" release

### DIFF
--- a/src/installer/source.d/python.py
+++ b/src/installer/source.d/python.py
@@ -100,8 +100,10 @@ def main() -> None:
     release_list = fetch_release_list()
     latest_minor_release: dict[tuple[int, int], Release] = {}
     for release in release_list:
+        if not release.slug.startswith("python-"):
+            continue
         version_parts = release.name.removeprefix("Python ").split(".")
-        assert len(version_parts) == 3
+        assert len(version_parts) == 3, version_parts
         minor_tuple = (int(version_parts[0]), int(version_parts[1]))
 
         if minor_tuple not in active_minor_release:


### PR DESCRIPTION
Interestingly, it seems that the PSF has released a new install manager for Windows, but all I really want is just the interpreter.

```json
[
    {
        "name": "Python 3.9.9",
        "slug": "python-399",
        ...
    },
    {
        "name": "Python install manager 25.0 beta 9",
        "slug": "pymanager-250b9",
        "version": 100,
        "is_published": true,
        "is_latest": true,
        "release_date": "2025-05-26T16:27:40Z",
        "pre_release": true,
        "release_page": null,
        "release_notes_url": "",
        "show_on_download_page": false,
        "resource_uri": "https://www.python.org/api/v2/downloads/release/1012/"
    }
]
```
```py
Traceback (most recent call last):
  File "/home/kntm2/repositories/dotfiles/src/installer/source.d/python.py", line 227, in <module>
    main()
  File "/home/kntm2/repositories/dotfiles/src/installer/source.d/python.py", line 104, in main
    assert len(version_parts) == 3, version_parts
           ^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: ['install manager 25', '0 beta 9']
```